### PR TITLE
Remove .browser from Zombie.

### DIFF
--- a/app/templates/support/world.js
+++ b/app/templates/support/world.js
@@ -1,6 +1,6 @@
 var zombie = require('zombie');
 var World = function World(callback) {
-    this.browser = new zombie.Browser(); // this.browser will be available in step definitions
+    this.browser = new zombie // this.browser will be available in step definitions
 
     this.visit = function (url, callback) {
         this.browser.visit(url, callback);


### PR DESCRIPTION
Zombie doesn't need .browser to instantiate anymore.
